### PR TITLE
[Fix] boxbutton 내부의 modifier를 인자로 받아온 걸로 교체

### DIFF
--- a/compose/src/main/kotlin/com/yourssu/handy/compose/button/BoxButton.kt
+++ b/compose/src/main/kotlin/com/yourssu/handy/compose/button/BoxButton.kt
@@ -69,7 +69,7 @@ fun BoxButton(
         colors = boxButtonColorByType(
             type = buttonType,
         ),
-        modifier = Modifier.height(height),
+        modifier = modifier.height(height),
         enabled = enabled,
         showBorder = (buttonType == BoxButtonType.Tertiary),
         interactionSource = interactionSource,


### PR DESCRIPTION
- Dialog 작업하다가 BoxButton이 마음대로 동작하지 않아서 발견한 문제입니다.
- 위 작업을 하던 브랜치에서 작업하려다가, BottomSheet 등 다른 연계된 컴포넌트가 있는 것 같아 별도의 브랜치로 분리하여 PR을 올립니다. 간단한 수정이니 빠른 Approve 부탁드립니다! 🙇‍♀️