### PR TITLE
Divider color token 변경 

### DIFF
--- a/app/src/main/kotlin/com/yourssu/handy/demo/DividerPreview.kt
+++ b/app/src/main/kotlin/com/yourssu/handy/demo/DividerPreview.kt
@@ -17,15 +17,18 @@ fun DividerExample() {
         Divider(
             dividerThickness = DividerThickness.TWO,
             width = 100.dp,
-            color = HandyTheme.colors.bgBasicBlack
+            color = HandyTheme.colors.lineBasicLight
         )
         Text("Section 2")
         Divider(
             dividerThickness = DividerThickness.FOUR,
             width = 200.dp,
-            color = HandyTheme.colors.bgBasicBlack
+            color = HandyTheme.colors.lineBasicMedium
         )
         Text("Section 3")
-        Divider(dividerThickness = DividerThickness.EIGHT, color = HandyTheme.colors.bgBasicBlack)
+        Divider(
+            dividerThickness = DividerThickness.EIGHT,
+            color = HandyTheme.colors.lineBasicStrong
+        )
     }
 }

--- a/compose/src/main/kotlin/com/yourssu/handy/compose/Divider.kt
+++ b/compose/src/main/kotlin/com/yourssu/handy/compose/Divider.kt
@@ -34,7 +34,7 @@ fun Divider(
     dividerThickness: DividerThickness,
     modifier: Modifier = Modifier,
     width: Dp = 0.dp,
-    color: Color = HandyTheme.colors.bgBasicStrong,
+    color: Color = HandyTheme.colors.lineBasicStrong,
 ) {
     Box(
         modifier = modifier
@@ -54,7 +54,7 @@ fun Divider(
 fun Divider(
     dividerThickness: DividerThickness,
     modifier: Modifier = Modifier,
-    color: Color = HandyTheme.colors.bgBasicStrong,
+    color: Color = HandyTheme.colors.lineBasicStrong,
 ) {
     Box(
         modifier = modifier

--- a/compose/src/main/kotlin/com/yourssu/handy/compose/foundation/SemanticColors.kt
+++ b/compose/src/main/kotlin/com/yourssu/handy/compose/foundation/SemanticColors.kt
@@ -37,12 +37,15 @@ data class ColorScheme(
     val textStatusNegative: Color = ColorStatusRedMain,
     val textStatusPositive: Color = ColorViolet500,
 
-    // Outlined / Basic
+    // Line / Basic
     val lineBasicLight: Color = ColorGray100,
     val lineBasicMedium: Color = ColorGray200,
     val lineBasicStrong: Color = ColorGray300,
 
-    // Outlined / Status
+    // Line / Brand
+    val lineBrandPrimary: Color = ColorViolet500,
+
+    // Line / Status
     val lineStatusNegative: Color = ColorStatusRedMain,
     val lineStatusPositive: Color = ColorViolet500,
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/5bb9606d-c2ce-4040-9037-2c7dc341cd1a)

변경된 Divider 토큰명에 따라 Divider color의 default color 값을 lineBasicStrong으로 수정했습니다.

한가지 고민되는 건 Divider도 그렇고 다른 컴포넌트들도 Color 지정이 너무 열려있는 건 아닌가 싶습니다.
material처럼 각 컴포넌트에 대한 컬러 객체를 만드는 게 어떨지 고민이 되네요..
이렇게 되면 컬러 커스텀이 또 까다로워지긴 할거라 고민입니다 